### PR TITLE
fix: take tagPrefix and path into account

### DIFF
--- a/cmd/versioner/main.go
+++ b/cmd/versioner/main.go
@@ -48,7 +48,7 @@ func main() {
 	var latest string
 	versionTag, err := tag.GetLatest(tagPrefix)
 	if err == nil {
-		latest = versionTag
+		latest = tagPrefix + versionTag
 	} else {
 		if strictMode {
 			fail(errors.New("couldn't compute last version tag"))

--- a/commit/range.go
+++ b/commit/range.go
@@ -24,7 +24,7 @@ func MessagesInRange(start, end, path string) ([]Message, error) {
 		logrange = fmt.Sprintf("%s...%s", start, end)
 	}
 
-	cmd := exec.Command("git", "log", logrange)
+	cmd := exec.Command("git", "log", logrange, path)
 	out, err := cmd.StdoutPipe()
 	if err != nil {
 		return []Message{}, nil


### PR DESCRIPTION
these 2 things were still missing to make prefix based versioning possible